### PR TITLE
Add extended bounds param to Histogram and DateHistogram

### DIFF
--- a/src/Aggregation/DateHistogramAggregation.php
+++ b/src/Aggregation/DateHistogramAggregation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Erichard\ElasticQueryBuilder\Aggregation;
 
+use Erichard\ElasticQueryBuilder\Features\HasExtendedBounds;
 use Erichard\ElasticQueryBuilder\Features\HasField;
 
 /**
@@ -11,7 +12,7 @@ use Erichard\ElasticQueryBuilder\Features\HasField;
  */
 class DateHistogramAggregation extends AbstractAggregation
 {
-    use HasField; // TODO enum
+    use HasField, HasExtendedBounds; // TODO enum
 
     /**
      * @param array<AbstractAggregation> $aggregations
@@ -20,10 +21,14 @@ class DateHistogramAggregation extends AbstractAggregation
         string $nameAndField,
         private string $calendarInterval,
         ?string $field = null,
-        array $aggregations = []
+        array $aggregations = [],
+        ?string $min = null,
+        ?string $max = null,
     ) {
         parent::__construct($nameAndField, $aggregations);
         $this->field = $field ?? $nameAndField;
+        $this->min = $min;
+        $this->max = $max;
     }
 
     public function setCalendarInterval(string $calendarInterval): self
@@ -45,9 +50,16 @@ class DateHistogramAggregation extends AbstractAggregation
 
     protected function buildAggregation(): array
     {
-        return [
+        $build = [
             'field' => $this->field,
             'calendar_interval' => $this->calendarInterval,
         ];
+
+        if ($this->min !== null && $this->max !== null) {
+            $build['extended_bounds']['min'] = $this->min;
+            $build['extended_bounds']['max'] = $this->max;
+        }
+
+        return $build;
     }
 }

--- a/src/Aggregation/HistogramAggregation.php
+++ b/src/Aggregation/HistogramAggregation.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Erichard\ElasticQueryBuilder\Aggregation;
 
+use Erichard\ElasticQueryBuilder\Features\HasExtendedBounds;
 use Erichard\ElasticQueryBuilder\Features\HasField;
 
 class HistogramAggregation extends AbstractAggregation
 {
-    use HasField;
+    use HasField, HasExtendedBounds;
 
     /**
      * @param array<AbstractAggregation> $aggregations
@@ -17,10 +18,14 @@ class HistogramAggregation extends AbstractAggregation
         string $name,
         string $field,
         private int $interval,
-        array $aggregations = []
+        array $aggregations = [],
+        ?string $min = null,
+        ?string $max = null,
     ) {
         parent::__construct($name, $aggregations);
         $this->field = $field;
+        $this->min = $min;
+        $this->max = $max;
     }
 
     public function getInterval(): int
@@ -40,9 +45,16 @@ class HistogramAggregation extends AbstractAggregation
 
     protected function buildAggregation(): array
     {
-        return [
+        $build = [
             'field' => $this->field,
             'interval' => $this->interval,
         ];
+
+        if ($this->min !== null && $this->max !== null) {
+            $build['extended_bounds']['min'] = $this->min;
+            $build['extended_bounds']['max'] = $this->max;
+        }
+
+        return $build;
     }
 }

--- a/src/Features/HasExtendedBounds.php
+++ b/src/Features/HasExtendedBounds.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Erichard\ElasticQueryBuilder\Features;
+
+/**
+ * @see  https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html#search-aggregations-bucket-histogram-aggregation-extended-bounds
+ */
+trait HasExtendedBounds
+{
+    protected ?string $min;
+
+    protected ?string $max;
+
+    public function setMin(?string $min): self
+    {
+        $this->min = $min;
+
+        return $this;
+    }
+
+    public function getMin(): ?string
+    {
+        return $this->min;
+    }
+
+    public function setMax(?string $max): self
+    {
+        $this->max = $max;
+
+        return $this;
+    }
+
+    public function getMax(): ?string
+    {
+        return $this->max;
+    }
+}

--- a/tests/Aggregation/DateHistogramAggregationTest.php
+++ b/tests/Aggregation/DateHistogramAggregationTest.php
@@ -47,4 +47,26 @@ class DateHistogramAggregationTest extends TestCase
             ],
         ], $aggregation->build());
     }
+
+    public function testWithExtendedBounds(): void
+    {
+        $nameAndField = 'per_day';
+        $calendarInterval = 'day';
+        $field = 'date';
+        $min = '2022-01-10';
+        $max = '2022-01-20';
+
+        $aggregation = new DateHistogramAggregation($nameAndField, $calendarInterval, $field, [], $min, $max);
+
+        $this->assertEquals([
+            'date_histogram' => [
+                'field' => $field,
+                'calendar_interval' => $calendarInterval,
+                'extended_bounds' => [
+                    'min' => $min,
+                    'max' => $max,
+                ],
+            ],
+        ], $aggregation->build());
+    }
 }


### PR DESCRIPTION
[Extended bounds](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html#search-aggregations-bucket-histogram-aggregation-extended-bounds) param prevents elastic from omitting buckets with no data from query result.