### PR TITLE
Direct support for pit and search_after in QueryBuilder

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -21,9 +21,9 @@ class QueryBuilder
 
     private ?int $size = null;
 
-	private string|array|null $pit = null;
+    private string|array|null $pit = null;
 
-	private ?array $searchAfter = null;
+    private ?array $searchAfter = null;
 
     private ?QueryInterface $query = null;
 
@@ -63,23 +63,23 @@ class QueryBuilder
         return $this;
     }
 
-	public function setPit(string|array|null $pit): self
-	{
-		if (is_array($pit) && !isset($pit['id'])) {
-			throw new \InvalidArgumentException('Parameter "pit" is not valid. Value with key "id" is not set.');
-		}
+    public function setPit(string|array|null $pit): self
+    {
+        if (is_array($pit) && !isset($pit['id'])) {
+            throw new \InvalidArgumentException('Parameter "pit" is not valid. Value with key "id" is not set.');
+        }
 
-		$this->pit = $pit;
+        $this->pit = $pit;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function setSearchAfter(?array $searchAfter): self
-	{
-		$this->searchAfter = $searchAfter;
+    public function setSearchAfter(?array $searchAfter): self
+    {
+        $this->searchAfter = $searchAfter;
 
-		return $this;
-	}
+        return $this;
+    }
 
     public function setQuery(QueryInterface $query): self
     {
@@ -135,17 +135,17 @@ class QueryBuilder
             $query['size'] = $this->size;
         }
 
-		if (null !== $this->pit) {
-			if (is_string($this->pit)) {
-				$query['pit'] = ['id' => $this->pit];
-			} else {
-				$query['pit'] = $this->pit;
-			}
-		}
+        if (null !== $this->pit) {
+            if (is_string($this->pit)) {
+                $query['pit'] = ['id' => $this->pit];
+            } else {
+                $query['pit'] = $this->pit;
+            }
+        }
 
-		if (null !== $this->searchAfter) {
-			$query['search_after'] = $this->searchAfter;
-		}
+        if (null !== $this->searchAfter) {
+            $query['search_after'] = $this->searchAfter;
+        }
 
         if (null !== $this->source) {
             $query['_source'] = $this->source;
@@ -189,15 +189,15 @@ class QueryBuilder
         return $this->size;
     }
 
-	public function getPit(): string|array|null
-	{
-		return $this->pit;
-	}
+    public function getPit(): string|array|null
+    {
+        return $this->pit;
+    }
 
-	public function getSearchAfter(): ?array
-	{
-		return $this->searchAfter;
-	}
+    public function getSearchAfter(): ?array
+    {
+        return $this->searchAfter;
+    }
 
     public function getQuery(): ?QueryInterface
     {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -21,6 +21,10 @@ class QueryBuilder
 
     private ?int $size = null;
 
+	private string|array|null $pit = null;
+
+	private ?array $searchAfter = null;
+
     private ?QueryInterface $query = null;
 
     private ?array $fields = null;
@@ -58,6 +62,24 @@ class QueryBuilder
 
         return $this;
     }
+
+	public function setPit(string|array|null $pit): self
+	{
+		if (is_array($pit) && !isset($pit['id'])) {
+			throw new \InvalidArgumentException('Parameter "pit" is not valid. Value with key "id" is not set.');
+		}
+
+		$this->pit = $pit;
+
+		return $this;
+	}
+
+	public function setSearchAfter(?array $searchAfter): self
+	{
+		$this->searchAfter = $searchAfter;
+
+		return $this;
+	}
 
     public function setQuery(QueryInterface $query): self
     {
@@ -113,6 +135,18 @@ class QueryBuilder
             $query['size'] = $this->size;
         }
 
+		if (null !== $this->pit) {
+			if (is_string($this->pit)) {
+				$query['pit'] = ['id' => $this->pit];
+			} else {
+				$query['pit'] = $this->pit;
+			}
+		}
+
+		if (null !== $this->searchAfter) {
+			$query['search_after'] = $this->searchAfter;
+		}
+
         if (null !== $this->source) {
             $query['_source'] = $this->source;
         }
@@ -154,6 +188,16 @@ class QueryBuilder
     {
         return $this->size;
     }
+
+	public function getPit(): string|array|null
+	{
+		return $this->pit;
+	}
+
+	public function getSearchAfter(): ?array
+	{
+		return $this->searchAfter;
+	}
 
     public function getQuery(): ?QueryInterface
     {

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -64,27 +64,27 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(50, $query['from']);
     }
 
-	public function testItSetThePitAsString(): void
-	{
-		$queryBuilder = new QueryBuilder();
+    public function testItSetThePitAsString(): void
+    {
+        $queryBuilder = new QueryBuilder();
 
-		$queryBuilder->setPit('pit-as-string');
+        $queryBuilder->setPit('pit-as-string');
 
-		$query = $queryBuilder->build();
+        $query = $queryBuilder->build();
 
-		$this->assertEquals(['id' => 'pit-as-string'], $query['pit']);
-	}
+        $this->assertEquals(['id' => 'pit-as-string'], $query['pit']);
+    }
 
-	public function testItSetThePitAsArray(): void
-	{
-		$queryBuilder = new QueryBuilder();
+    public function testItSetThePitAsArray(): void
+    {
+        $queryBuilder = new QueryBuilder();
 
-		$queryBuilder->setPit(['id' => 'pit-as-array', 'keep_alive' => '1m']);
+        $queryBuilder->setPit(['id' => 'pit-as-array', 'keep_alive' => '1m']);
 
-		$query = $queryBuilder->build();
+        $query = $queryBuilder->build();
 
-		$this->assertEquals(['id' => 'pit-as-array', 'keep_alive' => '1m'], $query['pit']);
-	}
+        $this->assertEquals(['id' => 'pit-as-array', 'keep_alive' => '1m'], $query['pit']);
+    }
 
     public function testItAllowToSort(): void
     {

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -64,6 +64,28 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(50, $query['from']);
     }
 
+	public function testItSetThePitAsString(): void
+	{
+		$queryBuilder = new QueryBuilder();
+
+		$queryBuilder->setPit('pit-as-string');
+
+		$query = $queryBuilder->build();
+
+		$this->assertEquals(['id' => 'pit-as-string'], $query['pit']);
+	}
+
+	public function testItSetThePitAsArray(): void
+	{
+		$queryBuilder = new QueryBuilder();
+
+		$queryBuilder->setPit(['id' => 'pit-as-array', 'keep_alive' => '1m']);
+
+		$query = $queryBuilder->build();
+
+		$this->assertEquals(['id' => 'pit-as-array', 'keep_alive' => '1m'], $query['pit']);
+	}
+
     public function testItAllowToSort(): void
     {
         $queryBuilder = new QueryBuilder();


### PR DESCRIPTION
This PR just added direct support for pit and search_after in QueryBuilder. See https://www.elastic.co/guide/en/elasticsearch/reference/master/paginate-search-results.html#search-after.