### PR TITLE
Add boolean and integer support to MatchQuery and AbstractMatchQuery

### DIFF
--- a/src/Query/AbstractMatchQuery.php
+++ b/src/Query/AbstractMatchQuery.php
@@ -11,7 +11,7 @@ abstract class AbstractMatchQuery implements QueryInterface
 
     public function __construct(
         string $field,
-        protected string $query,
+        protected string|bool $query,
         protected ?string $analyzer = null,
         protected array $params = [],
     ) {

--- a/src/Query/AbstractMatchQuery.php
+++ b/src/Query/AbstractMatchQuery.php
@@ -11,7 +11,7 @@ abstract class AbstractMatchQuery implements QueryInterface
 
     public function __construct(
         string $field,
-        protected string|bool $query,
+        protected string|bool|int $query,
         protected ?string $analyzer = null,
         protected array $params = [],
     ) {

--- a/src/Query/MatchQuery.php
+++ b/src/Query/MatchQuery.php
@@ -14,7 +14,7 @@ class MatchQuery extends AbstractMatchQuery
 
     public function __construct(
         string $field,
-        string $query,
+        string|bool $query,
         ?string $analyzer = null,
         ?string $operator = null,
         ?string $minimumShouldMatch = null,

--- a/src/Query/MatchQuery.php
+++ b/src/Query/MatchQuery.php
@@ -14,7 +14,7 @@ class MatchQuery extends AbstractMatchQuery
 
     public function __construct(
         string $field,
-        string|bool $query,
+        string|bool|int $query,
         ?string $analyzer = null,
         ?string $operator = null,
         ?string $minimumShouldMatch = null,

--- a/tests/Query/MatchQueryTest.php
+++ b/tests/Query/MatchQueryTest.php
@@ -52,7 +52,7 @@ class MatchQueryTest extends TestCase
     }
 
 
-    public function testItBuildTheQueryWithIntefer(): void
+    public function testItBuildTheQueryWithInteger(): void
     {
         $query = new MatchQuery('count', 1);
 

--- a/tests/Query/MatchQueryTest.php
+++ b/tests/Query/MatchQueryTest.php
@@ -51,4 +51,18 @@ class MatchQueryTest extends TestCase
             ],
         ], $query->build());
     }
+
+
+    public function testItBuildTheQueryWithIntefer(): void
+    {
+        $query = new MatchQuery('count', 1);
+
+        $this->assertEquals([
+            'match' => [
+                'count' => [
+                    'query' => 1
+                ],
+            ],
+        ], $query->build());
+    }
 }

--- a/tests/Query/MatchQueryTest.php
+++ b/tests/Query/MatchQueryTest.php
@@ -38,4 +38,17 @@ class MatchQueryTest extends TestCase
             ],
         ], $query->build());
     }
+
+    public function testItBuildTheQueryWithBoolean(): void
+    {
+        $query = new MatchQuery('is_closed', true);
+
+        $this->assertEquals([
+            'match' => [
+                'is_closed' => [
+                    'query' => 'a brown fox'
+                ],
+            ],
+        ], $query->build());
+    }
 }

--- a/tests/Query/MatchQueryTest.php
+++ b/tests/Query/MatchQueryTest.php
@@ -42,11 +42,10 @@ class MatchQueryTest extends TestCase
     public function testItBuildTheQueryWithBoolean(): void
     {
         $query = new MatchQuery('is_closed', true);
-
-        $this->assertEquals([
+        $this->assertSame([
             'match' => [
                 'is_closed' => [
-                    'query' => 'a brown fox'
+                    'query' => true
                 ],
             ],
         ], $query->build());
@@ -57,7 +56,7 @@ class MatchQueryTest extends TestCase
     {
         $query = new MatchQuery('count', 1);
 
-        $this->assertEquals([
+        $this->assertSame([
             'match' => [
                 'count' => [
                     'query' => 1


### PR DESCRIPTION
According to https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-match-query.html
MatchQuery should support boolean and integers.