### PR TITLE
Add missing factories

### DIFF
--- a/.php_cs.dist.php
+++ b/.php_cs.dist.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
+
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->exclude(__DIR__ . '/tests')
@@ -26,6 +28,7 @@ return (new PhpCsFixer\Config())
         'concat_space' => false,
         'declare_strict_types' => true,
         'native_function_invocation' => ['include' => []],
+        'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => true],
         PhpCsFixerCustomFixers\Fixer\DeclareAfterOpeningTagFixer::name() => true,
         PhpCsFixerCustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer::name() => true,
         PhpCsFixerCustomFixers\Fixer\NoImportFromGlobalNamespaceFixer::name() => true,

--- a/src/Aggregation/Aggregation.php
+++ b/src/Aggregation/Aggregation.php
@@ -107,4 +107,27 @@ class Aggregation
     {
         return new TopHitsAggregation($name, $aggregations);
     }
+
+    public static function histogram(string $name, string $field, int $interval): HistogramAggregation
+    {
+        return new HistogramAggregation($name, $field, $interval);
+    }
+
+    /**
+     * @param array<int> $ranges pass desired ranges that will be converted to linear range
+     */
+    public static function ranges(string $name, string $field, array $ranges): RangesAggregation
+    {
+        return new RangesAggregation($name, $field, $ranges);
+    }
+
+    public static function widthHistogram(string $name, string $field, int $buckets): WidthHistogramAggregation
+    {
+        return new WidthHistogramAggregation($name, $field, $buckets);
+    }
+
+    public static function stats(string $name): StatsAggregation
+    {
+        return new StatsAggregation($name);
+    }
 }

--- a/src/Aggregation/RangesAggregation.php
+++ b/src/Aggregation/RangesAggregation.php
@@ -14,7 +14,7 @@ class RangesAggregation extends AbstractAggregation
      * @param array<int>                 $ranges                  pass desired ranges that will be converted to
      *                                                            linear range
      * @param array<AbstractAggregation> $aggregations
-     * @param bool                       $equalConditionOnToRange Se to true if you want to do a histogram with 0
+     * @param bool                       $equalConditionOnToRange Set to true if you want to do a histogram with 0
      *                                                            - 10, 10 - 15, and correctly count the number
      *                                                            (entry with 10 will be in first and seconds
      *                                                            segment

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -49,9 +49,9 @@ class Query
         return new RangeQuery($field, $lt, $gt, $lte, $gte);
     }
 
-    public static function nested(string $field, QueryInterface $query): NestedQuery
+    public static function nested(?string $path, QueryInterface $query): NestedQuery
     {
-        return new NestedQuery($field, $query);
+        return new NestedQuery($path, $query);
     }
 
     public static function match(string $field, string $query): MatchQuery

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -84,6 +84,11 @@ class Query
         return new FunctionsQuery($field);
     }
 
+    public static function GeoBoundingBoxQuery(string $field): GeoBoundingBoxQuery
+    {
+        return new GeoBoundingBoxQuery($field);
+    }
+
     /**
      * @param float[]|int[] $position
      */
@@ -113,5 +118,18 @@ class Query
     public static function rankFeature(string $field): RankFeatureQuery
     {
         return new RankFeatureQuery($field);
+    }
+
+    public static function exists(string $field): ExistsQuery
+    {
+        return new ExistsQuery($field);
+    }
+
+    /**
+     * @param mixed[]|string[] $fields
+     */
+    public static function simpleQueryString(array $fields, string $query): SimpleQueryStringQuery
+    {
+        return new SimpleQueryStringQuery($fields, $query);
     }
 }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -110,7 +110,7 @@ class Query
         return new PrefixQuery($field, $value);
     }
 
-    public static function queryString(string $query, string $defaultField = null): QueryStringQuery
+    public static function queryString(string $query, ?string $defaultField = null): QueryStringQuery
     {
         return new QueryStringQuery($query, $defaultField);
     }

--- a/src/Query/SimpleQueryStringQuery.php
+++ b/src/Query/SimpleQueryStringQuery.php
@@ -3,10 +3,12 @@
 namespace Erichard\ElasticQueryBuilder\Query;
 
 use Erichard\ElasticQueryBuilder\Contracts\QueryInterface;
+use Erichard\ElasticQueryBuilder\Features\HasBoost;
 use Erichard\ElasticQueryBuilder\Features\HasMinimumShouldMatch;
 
 class SimpleQueryStringQuery implements QueryInterface
 {
+    use HasBoost;
     use HasMinimumShouldMatch;
 
     /**
@@ -167,6 +169,7 @@ class SimpleQueryStringQuery implements QueryInterface
         }
 
         $this->buildMinimumShouldMatchTo($data);
+        $this->buildBoostTo($data);
 
         $build = $this->params;
         $build['simple_query_string'] = $data;

--- a/src/Query/SimpleQueryStringQuery.php
+++ b/src/Query/SimpleQueryStringQuery.php
@@ -15,7 +15,6 @@ class SimpleQueryStringQuery implements QueryInterface
     public function __construct(
         protected array $fields,
         protected string $query,
-
         private ?string $flags = null,
         private ?bool $fuzzyTranspositions = null,
         private ?int $fuzzyMaxExpansions = null,
@@ -27,7 +26,6 @@ class SimpleQueryStringQuery implements QueryInterface
         private ?string $quoteFieldSuffix = null,
         private ?bool $analyzeWildCard = null,
         private ?bool $autoGenerateSynonymsPhraseQuery = null,
-
         protected array $params = [],
     ) {
         $this->minimumShouldMatch = $minimumShouldMatch;
@@ -36,69 +34,70 @@ class SimpleQueryStringQuery implements QueryInterface
     public function setFlags(string|null $flags): self
     {
         $this->flags = $flags;
+
         return $this;
     }
-
 
     public function setFuzzyTranspositions(bool|null $fuzzyTranspositions): self
     {
         $this->fuzzyTranspositions = $fuzzyTranspositions;
+
         return $this;
     }
-
 
     public function setFuzzyMaxExpansions(int|null $fuzzyMaxExpansions): self
     {
         $this->fuzzyMaxExpansions = $fuzzyMaxExpansions;
+
         return $this;
     }
-
 
     public function setFuzzyPrefixLength(int|null $fuzzyPrefixLength): self
     {
         $this->fuzzyPrefixLength = $fuzzyPrefixLength;
+
         return $this;
     }
-
 
     public function setDefaultOperator(string|null $defaultOperator): self
     {
         $this->defaultOperator = $defaultOperator;
+
         return $this;
     }
-
 
     public function setAnalyzer(string|null $analyzer): self
     {
         $this->analyzer = $analyzer;
+
         return $this;
     }
-
 
     public function setLenient(bool|null $lenient): self
     {
         $this->lenient = $lenient;
+
         return $this;
     }
-
 
     public function setQuoteFieldSuffix(string|null $quoteFieldSuffix): self
     {
         $this->quoteFieldSuffix = $quoteFieldSuffix;
+
         return $this;
     }
-
 
     public function setAnalyzeWildCard(bool|null $analyzeWildCard): self
     {
         $this->analyzeWildCard = $analyzeWildCard;
+
         return $this;
     }
-
 
     public function setAutoGenerateSynonymsPhraseQuery(bool|null $autoGenerateSynonymsPhraseQuery): self
     {
         $this->autoGenerateSynonymsPhraseQuery = $autoGenerateSynonymsPhraseQuery;
+
         return $this;
     }
 

--- a/tests/Query/GeoBoundingBoxQueryTest.php
+++ b/tests/Query/GeoBoundingBoxQueryTest.php
@@ -12,13 +12,13 @@ class GeoBoundingBoxQueryTest extends TestCase
 {
     public function testBuildFailsOnAllNull(): void
     {
-        $this->expectErrorMessage('GeoBoundingBoxQuery needs at least 2 sides set');
+        $this->expectExceptionMessage('GeoBoundingBoxQuery needs at least 2 sides set');
         (new GeoBoundingBoxQuery('test'))->build();
     }
 
     public function testBuildFailsOnOneFilter(): void
     {
-        $this->expectErrorMessage('GeoBoundingBoxQuery needs at least 2 sides set');
+        $this->expectExceptionMessage('GeoBoundingBoxQuery needs at least 2 sides set');
         (new GeoBoundingBoxQuery(field: 'test', topLeft: new GpsPointEntity(1.1, 2.1)))->build();
     }
 

--- a/tests/Query/SimpleQueryStringQueryTest.php
+++ b/tests/Query/SimpleQueryStringQueryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Erichard\ElasticQueryBuilder\Query;
 
-use Erichard\ElasticQueryBuilder\Query\MultiMatchQuery;
 use Erichard\ElasticQueryBuilder\Query\SimpleQueryStringQuery;
 use PHPUnit\Framework\TestCase;
 
@@ -93,5 +92,50 @@ class SimpleQueryStringQueryTest extends TestCase
                     'minimum_should_match' => '1%',
                 ],
         ], $query->build());
+    }
+
+    public function testItBuildTheQueryWithBoost(): void
+    {
+        $query = new SimpleQueryStringQuery(
+            ['subject', 'body'],
+            '~brown fox',
+            'ALL',
+            true,
+            50,
+            0,
+            "1%",
+            "or",
+            "standard",
+            false,
+            "",
+            false,
+            true
+
+        );
+        $query->setBoost(3);
+
+        $this->assertEquals([
+                'simple_query_string' =>
+                    [
+                        'query' => '~brown fox',
+                        'fields' =>
+                            [
+                                'subject',
+                                'body',
+                            ],
+                        'flags' => 'ALL',
+                        'fuzzy_transpositions' => true,
+                        'fuzzy_max_expansions' => 50,
+                        'fuzzy_prefix_length' => 0,
+                        'default_operator' => 'or',
+                        'analyzer' => 'standard',
+                        'lenient' => false,
+                        'quote_field_suffix' => '',
+                        'analyze_wildcard' => false,
+                        'auto_generate_synonyms_phrase_query' => true,
+                        'minimum_should_match' => '1%',
+                        'boost' => 3,
+                    ],
+        ], $query->build()); 
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -72,7 +72,7 @@ class QueryBuilderTest extends TestCase
 
         $query = $queryBuilder->build();
 
-        $this->assertEquals(['id' => 'pit-as-string'], $query['pit']);
+        $this->assertEquals(['id' => 'pit-as-string'], $query['body']['pit']);
     }
 
     public function testItSetThePitAsArray(): void
@@ -83,7 +83,7 @@ class QueryBuilderTest extends TestCase
 
         $query = $queryBuilder->build();
 
-        $this->assertEquals(['id' => 'pit-as-array', 'keep_alive' => '1m'], $query['pit']);
+        $this->assertEquals(['id' => 'pit-as-array', 'keep_alive' => '1m'], $query['body']['pit']);
     }
 
     public function testItAllowToSort(): void


### PR DESCRIPTION
- Add missing factory methods to `src/Query/Query.php`
- Add missing factory methods to `src/Aggregation/Aggregation.php`
- Applied code style linter
  - I did re-enable `use_nullable_type_declaration` that is set to off by the `symfony` rule set. It would other wise remove `null` from parameter type hint when the default value was set to `null`.
- Fixed a minor type I came across in a comment
- Fixed 2 deprecations warnings in tests
- Fixed 2 assertions in tests